### PR TITLE
[compile] downgrade typescript version to 5.2.2 to stop the crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         "@diia-inhouse/genproto": "^1.10.0",
         "type-fest": "4.8.1",
         "rimraf": "5.0.5",
-        "lockfile-lint": "4.13.1"
+        "lockfile-lint": "4.13.1",
+        "typescript": "5.2.2"
     },
     "resolutions": {
         "@babel/traverse": "7.23.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
         "baseUrl": ".",
         "strict": true
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
**Overview**

If typescript is not globally installed, command `npx tsc` will download the latest version of the package and will try to execute it. Unfortunately, it will fail with type-fest lib error.

<img width="1686" alt="image" src="https://github.com/diia-open-source/be-types/assets/6419758/f7c8c112-5f11-4faa-8def-ef2bf15c1020">

**Solution:**

- fix version of the tsc by defining it in devDependencies

**Resolution:**
- projects should avoid global packages installation and dependencies to them, it's a "BAD practice"

